### PR TITLE
Rewrite of the code to make it follow Swift guidelines

### DIFF
--- a/Example/Every.xcodeproj/project.pbxproj
+++ b/Example/Every.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3F191A0A1C3D91F600BF87C7 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F191A091C3D91F600BF87C7 /* ArrayExtension.swift */; };
 		BB8411CE1C3BC96600C8B12A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8411CD1C3BC96600C8B12A /* AppDelegate.swift */; };
 		BB8411D01C3BC96600C8B12A /* MasterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8411CF1C3BC96600C8B12A /* MasterViewController.swift */; };
 		BB8411D21C3BC96600C8B12A /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8411D11C3BC96600C8B12A /* DetailViewController.swift */; };
@@ -15,8 +16,8 @@
 		BB8411DA1C3BC96600C8B12A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BB8411D81C3BC96600C8B12A /* LaunchScreen.storyboard */; };
 		BB8411E51C3BC96600C8B12A /* EveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8411E41C3BC96600C8B12A /* EveryTests.swift */; };
 		BB8411F01C3BC96600C8B12A /* EveryUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8411EF1C3BC96600C8B12A /* EveryUITests.swift */; };
-		BB8412031C3BDD3200C8B12A /* Every.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8412011C3BDD3200C8B12A /* Every.swift */; settings = {ASSET_TAGS = (); }; };
-		BB8412041C3BDD3200C8B12A /* NSDateComponentsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8412021C3BDD3200C8B12A /* NSDateComponentsExtensions.swift */; settings = {ASSET_TAGS = (); }; };
+		BB8412031C3BDD3200C8B12A /* Every.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8412011C3BDD3200C8B12A /* Every.swift */; };
+		BB8412041C3BDD3200C8B12A /* NSDateComponentsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8412021C3BDD3200C8B12A /* NSDateComponentsExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,6 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3F191A091C3D91F600BF87C7 /* ArrayExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
 		BB8411CA1C3BC96600C8B12A /* Every.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Every.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB8411CD1C3BC96600C8B12A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BB8411CF1C3BC96600C8B12A /* MasterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterViewController.swift; sourceTree = "<group>"; };
@@ -104,6 +106,7 @@
 			isa = PBXGroup;
 			children = (
 				BB8412011C3BDD3200C8B12A /* Every.swift */,
+				3F191A091C3D91F600BF87C7 /* ArrayExtension.swift */,
 				BB8412021C3BDD3200C8B12A /* NSDateComponentsExtensions.swift */,
 				BB8411CD1C3BC96600C8B12A /* AppDelegate.swift */,
 				BB8411CF1C3BC96600C8B12A /* MasterViewController.swift */,
@@ -267,6 +270,7 @@
 				BB8411D21C3BC96600C8B12A /* DetailViewController.swift in Sources */,
 				BB8412041C3BDD3200C8B12A /* NSDateComponentsExtensions.swift in Sources */,
 				BB8412031C3BDD3200C8B12A /* Every.swift in Sources */,
+				3F191A0A1C3D91F600BF87C7 /* ArrayExtension.swift in Sources */,
 				BB8411D01C3BC96600C8B12A /* MasterViewController.swift in Sources */,
 				BB8411CE1C3BC96600C8B12A /* AppDelegate.swift in Sources */,
 			);

--- a/Example/Every/AppDelegate.swift
+++ b/Example/Every/AppDelegate.swift
@@ -16,8 +16,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
-        let splitViewController = self.window!.rootViewController as! UISplitViewController
-        let navigationController = splitViewController.viewControllers[splitViewController.viewControllers.count-1] as! UINavigationController
+        guard let splitViewController = self.window?.rootViewController as? UISplitViewController else { return false }
+        guard let navigationController = splitViewController.viewControllers[splitViewController.viewControllers.count-1] as? UINavigationController else { return false }
         navigationController.topViewController!.navigationItem.leftBarButtonItem = splitViewController.displayModeButtonItem()
         splitViewController.delegate = self
         return true

--- a/Example/Every/ArrayExtension.swift
+++ b/Example/Every/ArrayExtension.swift
@@ -1,0 +1,15 @@
+//
+//  ArrayExtension.swift
+//  Every
+//
+//  Created by Pierre TACCHI on 06/01/16.
+//  Copyright © 2016 Samhan. All rights reserved.
+//
+
+public extension Array where Element : Equatable {
+    mutating func removeObject(object : Generator.Element) {
+        if let index = self.indexOf(object) {
+            self.removeAtIndex(index)
+        }
+    }
+}

--- a/Example/Every/Base.lproj/LaunchScreen.storyboard
+++ b/Example/Every/Base.lproj/LaunchScreen.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8150" systemVersion="15A204g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8122"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -15,7 +15,6 @@
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                 </viewController>

--- a/Example/Every/Base.lproj/Main.storyboard
+++ b/Example/Every/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="H1p-Uh-vWS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="H1p-Uh-vWS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <scenes>
         <!--Master-->
@@ -22,7 +22,7 @@
         <!--Detail-->
         <scene sceneID="yUG-lL-AsK">
             <objects>
-                <viewController title="Detail" id="JEX-9P-axG" customClass="DetailViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController title="Detail" id="JEX-9P-axG" customClass="DetailViewController" customModule="Every" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="SYR-Wa-9uf"/>
                         <viewControllerLayoutGuide type="bottom" id="GAO-Cl-Wes"/>
@@ -35,7 +35,7 @@
                                 <rect key="frame" x="20" y="292" width="560" height="17"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <fontDescription key="fontDescription" type="system" size="system"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -73,24 +73,24 @@
         <!--Master-->
         <scene sceneID="smW-Zh-WAh">
             <objects>
-                <tableViewController title="Master" clearsSelectionOnViewWillAppear="NO" id="7bK-jq-Zjz" customClass="MasterViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController title="Master" clearsSelectionOnViewWillAppear="NO" id="7bK-jq-Zjz" customClass="MasterViewController" customModule="Every" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="r7i-6Z-zg0">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" textLabel="Arm-wq-HPj" style="IBUITableViewCellStyleDefault" id="WCw-Qf-5nD">
-                                <rect key="frame" x="0.0" y="86" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="86" width="600" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="WCw-Qf-5nD" id="37f-cq-3Eg">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Arm-wq-HPj">
-                                            <rect key="frame" x="15" y="0.0" width="290" height="43"/>
+                                            <rect key="frame" x="15" y="0.0" width="570" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         </label>
                                     </subviews>

--- a/Example/Every/DetailViewController.swift
+++ b/Example/Every/DetailViewController.swift
@@ -33,15 +33,14 @@ class DetailViewController: UIViewController {
 
     override func viewWillDisappear(animated: Bool) {
         super.viewWillDisappear(animated)
-        self.every_clearAllTimers()
+        TimerManager.clearTimersForOwner(self)
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
         self.configureView()
-        
-        every(3.seconds, owner: self) {
+        TimerManager.every(3.seconds, owner: self) {
             print("hello")
             return true
         }

--- a/Example/Every/DetailViewController.swift
+++ b/Example/Every/DetailViewController.swift
@@ -9,16 +9,11 @@
 import UIKit
 
 class DetailViewController: UIViewController {
-
     @IBOutlet weak var detailDescriptionLabel: UILabel!
 
-    deinit
-    {
+    deinit {
         print("deinit!")
-        
     }
-    
-
 
     var detailItem: AnyObject? {
         didSet {
@@ -36,7 +31,6 @@ class DetailViewController: UIViewController {
         }
     }
 
-    
     override func viewWillDisappear(animated: Bool) {
         super.viewWillDisappear(animated)
         self.every_clearAllTimers()
@@ -47,18 +41,15 @@ class DetailViewController: UIViewController {
         // Do any additional setup after loading the view, typically from a nib.
         self.configureView()
         
-        every(1.minutes + 3.seconds, owner: self) {
+        every(3.seconds, owner: self) {
             print("hello")
             return true
         }
-
     }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
-
-
 }
 

--- a/Example/Every/Every.swift
+++ b/Example/Every/Every.swift
@@ -11,109 +11,63 @@ import ObjectiveC
 
 var AssociatedObjectHandle: UInt8 = 0
 
-
-extension Array where Element : Equatable {
-
-    mutating func removeObject(object : Generator.Element) {
-        if let index = self.indexOf(object) {
-            self.removeAtIndex(index)
-        }
-    }
-}
-
-
 extension NSObject {
-    var every_timers:[TimerManager] {
+    var every_timers: [TimerManager] {
         get {
-            let exists : [TimerManager]? =  objc_getAssociatedObject(self, &AssociatedObjectHandle) as? [TimerManager]
-            
-            if exists == nil {
-                self.every_timers = []
-            }
-            
-            return objc_getAssociatedObject(self, &AssociatedObjectHandle) as! [TimerManager]
-            
-            
+            return objc_getAssociatedObject(self, &AssociatedObjectHandle) as? [TimerManager] ?? []
         }
         set {
             objc_setAssociatedObject(self, &AssociatedObjectHandle, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
         }
     }
     
-    func every_clearAllTimers()
-    {
-        self.every_timers.forEach { $0.clearTimer()}
+    func every_clearAllTimers() {
+        self.every_timers.forEach { $0.clearTimer() }
         self.every_timers = []
     }
 
-    func every_removeManager(let man : TimerManager)
-    {
+    func every_removeManager(let man : TimerManager) {
         self.every_timers.removeObject(man)
     }
 }
 
 
 
-class TimerManager : NSObject
-{
-    var timer       : NSTimer?
-    var closure     : (()->Bool)?
-    weak var owner  : NSObject?
+class TimerManager: NSObject {
+    var timer: NSTimer?
+    var closure: (() -> Bool)?
+    weak var owner: NSObject?
     
-    
-    init( let closure : (()->Bool) ,  let owner : NSObject?)
-    {
+    init(let closure: () -> Bool,  let owner: NSObject?) {
         self.closure = closure
         self.owner = owner
         super.init()
         self.owner?.every_timers.append(self)
-
     }
     
-    func startTimerWithDuration(let duration : NSTimeInterval)
-    {
+    func startTimerWithDuration(let duration : NSTimeInterval) {
         self.timer = NSTimer.scheduledTimerWithTimeInterval(duration, target: self, selector: "executeClosure", userInfo: nil, repeats: true)
     }
     
-    func executeClosure()
-    {
-        if let closure = self.closure {
-            
-            if let _ = owner {
-                
-                let result = closure()
-                
-                if !result {
-                    self.clearTimer()
-                }
-                
-
-            }
-            else {
-                self.clearTimer()
-            }
-            
+    func executeClosure() {
+        guard let closure = self.closure where self.owner != nil && closure() else {
+            clearTimer()
+            return
         }
-        
     }
     
-    func clearTimer()
-    {
+    private func clearTimer() {
         self.timer?.invalidate()
         self.timer = nil
         self.owner?.every_removeManager(self)
     }
     
-    deinit
-    {
+    deinit {
         self.clearTimer()
     }
 }
 
-
-func every(let duration : NSDateComponents , let owner : NSObject, let closure : ()->Bool)
-{
+func every(let duration: NSDateComponents , let owner: NSObject, let closure: () -> Bool) {
     let manager = TimerManager(closure: closure, owner: owner)
-
     manager.startTimerWithDuration(duration.durationInSeconds())
 }

--- a/Example/Every/MasterViewController.swift
+++ b/Example/Every/MasterViewController.swift
@@ -9,29 +9,24 @@
 import UIKit
 
 class MasterViewController: UITableViewController {
-
-    var detailViewController: DetailViewController? = nil
-    var objects = [AnyObject]()
-
+    private var detailViewController: DetailViewController?
+    private var objects = [AnyObject]()
 
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
         self.navigationItem.leftBarButtonItem = self.editButtonItem()
-
         let addButton = UIBarButtonItem(barButtonSystemItem: .Add, target: self, action: "insertNewObject:")
         self.navigationItem.rightBarButtonItem = addButton
         if let split = self.splitViewController {
             let controllers = split.viewControllers
-            self.detailViewController = (controllers[controllers.count-1] as! UINavigationController).topViewController as? DetailViewController
+            self.detailViewController = (controllers[controllers.count-1] as? UINavigationController)?.topViewController as? DetailViewController
         }
     }
 
     override func viewWillAppear(animated: Bool) {
         self.clearsSelectionOnViewWillAppear = self.splitViewController!.collapsed
         super.viewWillAppear(animated)
-        
-        
     }
 
     override func didReceiveMemoryWarning() {
@@ -90,7 +85,4 @@ class MasterViewController: UITableViewController {
             // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view.
         }
     }
-
-
 }
-

--- a/Example/Every/NSDateComponentsExtensions.swift
+++ b/Example/Every/NSDateComponentsExtensions.swift
@@ -8,12 +8,13 @@
 
 import Foundation
 
-
-let secPerMinute = 60
-let secPerHour   = secPerMinute * 60
-let secPerDay    = secPerHour * 24
-let secPerMonth  = secPerDay * 30
-let secPerYear   = secPerMonth * 12
+private struct DateConstants {
+    static let secPerMinute = 60
+    static let secPerHour   = secPerMinute * 60
+    static let secPerDay    = secPerHour * 24
+    static let secPerMonth  = secPerDay * 30
+    static let secPerYear   = secPerMonth * 12
+}
 
 public extension NSDateComponents
 {
@@ -29,73 +30,64 @@ public extension NSDateComponents
         return new
     }
     
-    func durationInSeconds()->NSTimeInterval
+    func durationInSeconds() -> NSTimeInterval
     {
-        let secAndMin =     self.second + self.minute * secPerMinute
-        let hourAndDay =    self.hour * secPerHour + self.day * secPerDay
-        let monthAndYear     =    self.month * secPerMonth + self.year * secPerYear
-        return Double(secAndMin + hourAndDay + monthAndYear)
+        let secAndMin = self.second + self.minute * DateConstants.secPerMinute
+        let hourAndDay = self.hour * DateConstants.secPerHour + self.day * DateConstants.secPerDay
+        let monthAndYear = self.month * DateConstants.secPerMonth + self.year * DateConstants.secPerYear
+        return NSTimeInterval(secAndMin + hourAndDay + monthAndYear)
     }
     
 }
 
 
-public extension Int
-{
-    public var hours : NSDateComponents
-        {
-            let components : NSDateComponents = NSDateComponents.zero()
+public extension Int {
+    public var hours: NSDateComponents {
+            let components = NSDateComponents.zero()
             components.hour = self
             return components
     }
     
-    public var minutes : NSDateComponents
-        {
-            let components : NSDateComponents = NSDateComponents.zero()
+    public var minutes: NSDateComponents {
+            let components = NSDateComponents.zero()
             components.minute = self
             return components
     }
     
-    public var seconds : NSDateComponents
-        {
-            let components : NSDateComponents = NSDateComponents.zero()
+    public var seconds: NSDateComponents {
+            let components = NSDateComponents.zero()
             components.second = self
             return components
     }
     
-    public var days : NSDateComponents
-        {
-            let components : NSDateComponents = NSDateComponents.zero()
+    public var days: NSDateComponents {
+            let components = NSDateComponents.zero()
             components.day = self
             return components
     }
     
-    public var months : NSDateComponents
-        {
-            let components : NSDateComponents = NSDateComponents.zero()
+    public var months : NSDateComponents {
+            let components = NSDateComponents.zero()
             components.month = self
             return components
     }
     
-    public var weeks : NSDateComponents
-        {
-            let components : NSDateComponents = NSDateComponents.zero()
+    public var weeks: NSDateComponents {
+            let components = NSDateComponents.zero()
             components.day = self*7
             return components
     }
     
     
-    public var years : NSDateComponents
-        {
-            let components : NSDateComponents = NSDateComponents.zero()
+    public var years: NSDateComponents {
+            let components = NSDateComponents.zero()
             components.year = self
             return components
     }
     
 }
 
-public func + (let compOne : NSDateComponents , compTwo : NSDateComponents)->NSDateComponents
-{
+public func +(let compOne: NSDateComponents , compTwo: NSDateComponents) -> NSDateComponents {
     let newComponent = NSDateComponents()
     newComponent.minute = compOne.minute + compTwo.minute
     newComponent.second = compOne.second + compTwo.second
@@ -107,7 +99,6 @@ public func + (let compOne : NSDateComponents , compTwo : NSDateComponents)->NSD
 }
 
 
-public func - (let frmDate : NSDate , let toDate : NSDate) -> NSDateComponents
-{
-    return NSCalendar.currentCalendar().components([.Year,.Month,.Day,.Hour,.Minute,.Second], fromDate: toDate, toDate: frmDate, options: NSCalendarOptions(rawValue:0))
+public func -(let frmDate: NSDate , let toDate: NSDate) -> NSDateComponents{
+    return NSCalendar.currentCalendar().components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: toDate, toDate: frmDate, options: NSCalendarOptions(rawValue:0))
 }

--- a/Example/Every/NSDateComponentsExtensions.swift
+++ b/Example/Every/NSDateComponentsExtensions.swift
@@ -80,14 +80,13 @@ public extension Int {
     
     
     public var years: NSDateComponents {
-            let components = NSDateComponents.zero()
-            components.year = self
-            return components
+        let components = NSDateComponents.zero()
+        components.year = self
+        return components
     }
-    
 }
 
-public func +(let compOne: NSDateComponents , compTwo: NSDateComponents) -> NSDateComponents {
+public func +(compOne: NSDateComponents , compTwo: NSDateComponents) -> NSDateComponents {
     let newComponent = NSDateComponents()
     newComponent.minute = compOne.minute + compTwo.minute
     newComponent.second = compOne.second + compTwo.second
@@ -99,6 +98,6 @@ public func +(let compOne: NSDateComponents , compTwo: NSDateComponents) -> NSDa
 }
 
 
-public func -(let frmDate: NSDate , let toDate: NSDate) -> NSDateComponents{
+public func -(frmDate: NSDate , toDate: NSDate) -> NSDateComponents{
     return NSCalendar.currentCalendar().components([.Year, .Month, .Day, .Hour, .Minute, .Second], fromDate: toDate, toDate: frmDate, options: NSCalendarOptions(rawValue:0))
 }

--- a/README.md
+++ b/README.md
@@ -3,17 +3,18 @@
 
 ## Usage
 
-        every(1.minutes + 3.seconds, owner: self) {
-            print("hello")
-            return true
-        }
+```
+TimerManager.every(3.seconds, owner: self) {
+    print("hello")
+    return true
+}
+```
 
 Prints "hello" every 1 minute and 3 seconds. Timer is invalidated whenever the owner is deallocated. 
 
-Return true from the closure to continue , false to invalidate the timer.
+Return `true` from the closure to continue , `false` to invalidate the timer.
 
-Alternatively , you can use the following category method to invalidate all timers:
-
-    self.every_clearAllTimers()
+Alternatively , you can use the following static method to invalidate all timers:
+`TimerManager.clearTimersForOwner(self)`
 
 


### PR DESCRIPTION
I got rid of the Objective-C API dependency.
I made it the _swift-way_. I don't think it's a good thing to extend all `NSObject` instances. It's better to make some sort of _new_ API and write dedicated objects to handle it.

This way I think it's clearer and more secure.

Ideally I'll rewrite it to be a Cocoa framework. I had to put some structs and classes into the same file, a framework would make it  easier to put each struct and class in its own file.
