### PR TITLE
made the TimerManageable protocol's extension's methods public

### DIFF
--- a/src/TimerManageableProtocol.swift
+++ b/src/TimerManageableProtocol.swift
@@ -19,15 +19,15 @@ extension TimerManageable {
         return TimerManager.every(interval, owner: self, elapsedHandler: elapsedHandler)
     }
     
-    func clearTimer(handler: TimerHandler) {
+    public func clearTimer(handler: TimerHandler) {
         TimerManager.clearTimer(handler)
     }
     
-    func clearTimers() {
+    public func clearTimers() {
         TimerManager.clearTimersForOwner(self)
     }
     
-    func clearAllTimers() {
+    public func clearAllTimers() {
         TimerManager.clearAllTimers()
     }
 }


### PR DESCRIPTION
When installing via cocoapods, the default implementations of TimerManageable's methods are not used. Swift asks the user to implement them in the conforming class. Declaring methods as public solves the issue.
